### PR TITLE
feat: use phantomjs npm module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+.idea/*

--- a/index.js
+++ b/index.js
@@ -19,9 +19,9 @@ PhantomJSBrowser.prototype = {
   name: 'PhantomJS',
 
   DEFAULT_CMD: {
-    linux: 'phantomjs',
-    darwin: '/usr/local/bin/phantomjs',
-    win32: process.env.ProgramFiles + '\\PhantomJS\\phantomjs.exe'
+    linux: require('phantomjs').path,
+    darwin: require('phantomjs').path,
+    win32: require('phantomjs').path
   },
   ENV_CMD: 'PHANTOMJS_BIN'
 };

--- a/package.json
+++ b/package.json
@@ -16,7 +16,9 @@
     "phantomjs"
   ],
   "author": "Vojta Jina <vojta.jina@gmail.com>",
-  "dependencies": {},
+  "dependencies": {
+    "phantomjs": "~1.8"
+  },
   "peerDependencies": {
     "karma": "~0.9"
   },


### PR DESCRIPTION
When the phantomjs npm module is installed it includes the
phantomjs binary native to the OS. Using this binary allows
Karma to launch tests via PhantomJS "out of the box," without
the need for users to install PhantomJS manually or worry
about configuring the path to their PhantomJS executable.

Users are still free to install their own copy of PhantomJS
and override the PHANTOMJS_BIN environment variable.

Closes #1
