### PR TITLE
fix: Depend on PhantomJS 1.9 to fix path issue and be at latest stable.

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   ],
   "author": "Vojta Jina <vojta.jina@gmail.com>",
   "dependencies": {
-    "phantomjs": "~1.8"
+    "phantomjs": "~1.9"
   },
   "peerDependencies": {
     "karma": "~0.9"


### PR DESCRIPTION
I was having issues with require('phantomjs').path not pointing to correctly place and finally found a ton of other people having same issue. 

PhantomJS 1.9 dependency fixes this issue. 1.9 has been out a while and fixes some other legit bugs in 1.8 so it'll be good to upgrade.

References: 
- gruntjs/grunt-lib-phantomjs#17
- https://groups.google.com/forum/#!searchin/karma-users/phantomjs/karma-users/20l4wI1YUnA/jgTZkektpvQJ
