### PR TITLE
Adds support for local installation of phantomjs. Fixes #31

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,14 +13,16 @@ var win32PhantomJSPath = function () {
   // get the path stored in phantomjs\lib\location.js, someting like
   //   "C:\\Users\\user-name\\AppData\\Roaming\\npm\\phantomjs.CMD"
   var cmd = require('phantomjs').path;
+  var absolutePath = path.dirname(cmd);
 
-  // get the global npm install directory by removing the filename from cmd variable
-  var npmGlobalRoot = path.dirname(cmd);
+  // for a local install, we get the ".exe" for a global install we get the ".cmd"
+  var packageRoot, isLocal = (path.extname(cmd) === ".exe");
+  if (isLocal) {
+    packageRoot = path.join(absolutePath, '/../..');
+    return path.join(packageRoot, '/bin/phantomjs');
+  }
 
-  // add known path
-  var phantom = npmGlobalRoot + '\\node_modules\\phantomjs\\bin\\phantomjs';
-
-  return phantom;
+  return path.join(absolutePath, '/node_modules/phantomjs/bin/phantomjs');
 };
 
 var PhantomJSBrowser = function(baseBrowserDecorator, config, args) {


### PR DESCRIPTION
I had some troubles using local installs with the latest version, as I see others have in issue #31.
This seem to be due to the pull request #29.

In CI-systems it makes sense to have local installations to not mix versions. 

In my case the `cmd` variable (`location` from PhantomJS) was 

```
somedir\node_modules\phantomjs\lib\phantom\phantomjs.exe
```

which caused the `phantom`-variable to be 

```
somedir\node_modules\phantomjs\lib\phantom\node_modules\phantomjs\bin\phantomjs
```

This is a non existing path, as the path really is without the `lib\phantom`.

I'm not entirely sure that this is correct for all instances and all cases, but by removing the `lib/phantom` it worked with both global and local installs on our system - with fresh installs. 

It would be great if e.g. @gillius could test this as well.
