### PR TITLE
Adding console output to phantomjs

### DIFF
--- a/capture.template.js
+++ b/capture.template.js
@@ -15,6 +15,10 @@
   page.settings.<%= key %> = <%= value %>
   <% }) %>
 
+  page.onConsoleMessage = function () {
+      console.log.apply(console, arguments)
+  }
+
   <% if (debug) { %>
   function debugPage() {
     console.log('Launch the debugger page at http://localhost:9000/webkit/inspector/inspector.html?page=2')

--- a/index.js
+++ b/index.js
@@ -71,6 +71,14 @@ var PhantomJSBrowser = function (baseBrowserDecorator, config, args, logger) {
     // and start phantomjs
     this._execCommand(this._getCommand(), flags)
 
+    this._process.stderr.on('data', function (data) {
+      log.error('' + data)
+    })
+
+    this._process.stdout.on('data', function (data) {
+      log.debug('' + data)
+    })
+
     if (args.debug) {
       log.info('ACTION REQUIRED:')
       log.info('')


### PR DESCRIPTION
Adding ability for phantomjs standard error and stdout to be pushed to console.  Also logging browser console messages to stdout.

Resolves #18 partially.