### PR TITLE
fixed a bug that made README.md unavailanle to npm

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,4 +1,4 @@
-.*
-
+.npmignore
+.gitignore
 Gruntfile.coffee
 CONTRIBUTING.md


### PR DESCRIPTION
README.md could not be read so in NPM respository (https://www.npmjs.org/package/karma-phantomjs-launcher)
it showed the following error:
ERROR: No README data found!

Also when people use this package, npm install shows the following error:
npm WARN package.json karma-phantomjs-launcher@0.1.4 No README data

closes #39