### PR TITLE
Update to use the latest phantomjs 1.9.12

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   ],
   "author": "Vojta Jina <vojta.jina@gmail.com>",
   "dependencies": {
-    "phantomjs": "~1.9.12"
+    "phantomjs": "1.9.12"
   },
   "peerDependencies": {
     "karma": ">=0.9"


### PR DESCRIPTION
The phantomjs that gets installed by default by npm 2.1.7 is 1.9.7, which fails because the URL to download phantomjs throws a 403
