### PR TITLE
Avoid shadowing original flags

### DIFF
--- a/index.js
+++ b/index.js
@@ -47,10 +47,8 @@ var PhantomJSBrowser = function(baseBrowserDecorator, config, args) {
         optionsCode.join('\n') + '\npage.open("' + url + '");\n';
     fs.writeFileSync(captureFile, captureCode);
 
-    flags = flags.concat(captureFile);
-
     // and start phantomjs
-    this._execCommand(this._getCommand(), flags);
+    this._execCommand(this._getCommand(), flags.concat(captureFile));
   };
 };
 


### PR DESCRIPTION
While trying to debug PhantomJS start failures, I noticed that the argument list to the `phantomjs` binary was growing with each attempt.

Instead of shadowing the original `flags` with the concatenated flags, this passes the concatenated flags to `_execCommand`.

Below is sample output without this change (with each attempt, the `capture.js` script is passed an additional time).

```
INFO [launcher]: Starting browser PhantomJS
DEBUG [temp-dir]: Creating temp dir at /tmp/www_checkout/karma-14590090
DEBUG [launcher]: /tmp/www_checkout/node_modules/karma-phantomjs-launcher/node_modules/phantomjs/lib/phantom/bin/phantomjs /tmp/www_checkout/karma-14590090/capture.js
DEBUG [launcher]: Process PhantomJS exited with code 127
ERROR [launcher]: Cannot start PhantomJS
	
DEBUG [temp-dir]: Cleaning temp dir /tmp/www_checkout/karma-14590090
DEBUG [framework.browserify]: building bundle
INFO [launcher]: Trying to start PhantomJS again (1/2).
DEBUG [launcher]: Restarting PhantomJS
DEBUG [temp-dir]: Creating temp dir at /tmp/www_checkout/karma-14590090
DEBUG [launcher]: /tmp/www_checkout/node_modules/karma-phantomjs-launcher/node_modules/phantomjs/lib/phantom/bin/phantomjs /tmp/www_checkout/karma-14590090/capture.js /tmp/www_checkout/karma-14590090/capture.js
DEBUG [framework.browserify]: updating src/scenes/util/geom.test.js in bundle
DEBUG [launcher]: Process PhantomJS exited with code 127
ERROR [launcher]: Cannot start PhantomJS
	
DEBUG [temp-dir]: Cleaning temp dir /tmp/www_checkout/karma-14590090
INFO [launcher]: Trying to start PhantomJS again (2/2).
DEBUG [launcher]: Restarting PhantomJS
DEBUG [temp-dir]: Creating temp dir at /tmp/www_checkout/karma-14590090
DEBUG [launcher]: /tmp/www_checkout/node_modules/karma-phantomjs-launcher/node_modules/phantomjs/lib/phantom/bin/phantomjs /tmp/www_checkout/karma-14590090/capture.js /tmp/www_checkout/karma-14590090/capture.js /tmp/www_checkout/karma-14590090/capture.js
DEBUG [launcher]: Process PhantomJS exited with code 127
ERROR [launcher]: Cannot start PhantomJS
	
DEBUG [temp-dir]: Cleaning temp dir /tmp/www_checkout/karma-14590090
ERROR [launcher]: PhantomJS failed 2 times (cannot start). Giving up.
DEBUG [karma]: Run complete, exiting.
DEBUG [launcher]: Disconnecting all browsers
```

Incidentally, if anybody knows how to get PhantomJS to launch on Ubuntu 12.04.5 with Node 0.10.32 and `phantomjs@1.9.13`, I'd appreciate any tips (in addition to Node, I've installed `libfontconfig1`, `fontconfig`, `libfontconfig1-dev`, and `libfreetype6-dev` debs).
