### PR TITLE
Moved PhantomJS to peer dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,11 +16,9 @@
     "phantomjs"
   ],
   "author": "Vojta Jina <vojta.jina@gmail.com>",
-  "dependencies": {
-    "phantomjs": "~1.9"
-  },
   "peerDependencies": {
-    "karma": ">=0.9"
+    "karma": ">=0.9",
+    "phantomjs": ">=1.9"
   },
   "license": "MIT",
   "devDependencies": {


### PR DESCRIPTION
Prior to this commit, installing `karma-phantomjs-launcher` would override the currently installed version of [PhantomJS](https://www.npmjs.com/package/phantomjs) with the one being requested by `karma-phantomjs-launcher`.

Instead of doing that, the launcher should passively accept whichever version of PhantomJS is currently installed. This way, if the developer was expecting a specific version of PhantomJS, installing `karma-phantomjs-launcher` would not perform any override.

Not having PhantomJS be a peer dependency became problematic for me when I wanted to use PhantomJS 2.0, rather than 1.9. I would have PhantomJS 2.0 installed, but installing `karma-phantomjs-launcher` would pretty much wipe out the 2.0, and install 1.9.