### PR TITLE
feat: Support option for phantom to exit on ResourceError

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,11 @@ module.exports = function(config) {
         flags: ['--load-images=true'],
         debug: true
       }
+    },
+
+    phantomjsLauncher: {
+      // Have phantomjs exit if a ResourceError is encountered (useful if karma exits without killing phantom)
+      exitOnResourceError: true
     }
   });
 };

--- a/capture.template.js
+++ b/capture.template.js
@@ -1,10 +1,21 @@
-var system = require('system'),
-fs = require('fs'),
-webpage = require('webpage');
-
 (function (phantom) {
-  var page = webpage.create();
+  var page = require('webpage').create();
 
+  <% if (exitOnResourceError) { %>
+  page.onResourceError = function() {
+    phantom.exit(1);
+  };
+  <% } %>
+
+  <% _.forOwn(pageOptions, function(value, key) { %>
+  page.<%= key %> = <%= value %>;
+  <% }); %>
+
+  <% _.forOwn(pageSettingsOptions, function(value, key) { %>
+  page.settings.<%= key %> = <%= value %>;
+  <% }); %>
+
+  <% if (debug) { %>
   function debugPage() {
     console.log('Launch the debugger page at http://localhost:9000/webkit/inspector/inspector.html?page=2');
 
@@ -19,4 +30,7 @@ webpage = require('webpage');
     setTimeout(launchPage, 15000);
   }
   debugPage();
+  <% } else { %>
+  page.open('<%= url %>');
+  <% } %>
 }(phantom));


### PR DESCRIPTION
If karma or grunt exit before being able to kill phantomjs, the
phantomjs process will live on as a zombie. This change allows phantomjs
to exit when it hits a resource error (like karma disappearing).

It is enabled by a config option exitOnResourceError.

See http://phantomjs.org/api/webpage/handler/on-resource-error.html for details.