### PR TITLE
Add the ability to specify a module for customizing a page before run.

### DIFF
--- a/capture.template.js
+++ b/capture.template.js
@@ -15,6 +15,10 @@
   page.settings.<%= key %> = <%= value %>
   <% }) %>
 
+  <% if (customizePageModule) { %>
+    require("<%= customizePageModule %>")(page);
+  <% } %>
+
   <% if (debug) { %>
   function debugPage() {
     console.log('Launch the debugger page at http://localhost:9000/webkit/inspector/inspector.html?page=2')

--- a/customize_page.js
+++ b/customize_page.js
@@ -1,0 +1,3 @@
+module.exports = function (page) {
+  // Access the page and do stuff to it here.
+}

--- a/index.js
+++ b/index.js
@@ -61,7 +61,8 @@ var PhantomJSBrowser = function (baseBrowserDecorator, config, args, logger) {
       exitOnResourceError: config && config.exitOnResourceError,
       pageOptions: pageOptions,
       pageSettingsOptions: pageSettingsOptions,
-      url: url
+      url: url,
+      customizePageModule: args.customizePageModule
     })
 
     fs.writeFileSync(captureFile, captureCode)

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -43,7 +43,14 @@ module.exports = function (config) {
 
     // start these browsers
     // available browser launchers: https://npmjs.org/browse/keyword/karma-launcher
-    browsers: ['PhantomJS'],
+    browsers: ['PhantomJS', 'PhantomJS_custom'],
+
+    customLaunchers: {
+      'PhantomJS_custom': {
+        base: 'PhantomJS',
+        customizePageModule: require.resolve("./customize_page")
+      }
+    },
 
     // Continuous Integration mode
     // if true, Karma captures browsers, runs the tests and exits


### PR DESCRIPTION
As mentioned by a number of the issues in the tracker, many users want to be able to access certain features of PhantomJS via their javascript test files, such as taking screenshots.  One way to do that is to use apis such as the page.onCallback which can be configured to communicate with the client JS page.  This simple approach allows one to specify a module path to load and use the exported function to configure the test page in order to provide such functionality.  Simple configuration, but alot of value and customizability is gained.