### PR TITLE
Fixed PhantomJS cmd-line flags passing

### DIFF
--- a/index.js
+++ b/index.js
@@ -29,7 +29,7 @@ var PhantomJSBrowser = function (baseBrowserDecorator, config, args, logger) {
   baseBrowserDecorator(this)
 
   var options = args && args.options || config && config.options || {}
-  var flags = args && args.flags || config && config.flags || []
+  var providedFlags = args && args.flags || config && config.flags || []
 
   this._start = function (url) {
     // create the js file that will open karma
@@ -48,6 +48,7 @@ var PhantomJSBrowser = function (baseBrowserDecorator, config, args, logger) {
       }
     })
 
+    var flags = _.clone(providedFlags);
     if (args.debug) {
       flags = flags.concat('--remote-debugger-port=9000')
       flags = flags.concat('--remote-debugger-autorun=yes')

--- a/index.js
+++ b/index.js
@@ -48,12 +48,6 @@ var PhantomJSBrowser = function (baseBrowserDecorator, config, args, logger) {
       }
     })
 
-    var flags = _.clone(providedFlags);
-    if (args.debug) {
-      flags.push('--remote-debugger-port=9000')
-      flags.push('--remote-debugger-autorun=yes')
-    }
-
     var file = fs.readFileSync(path.join(__dirname, 'capture.template.js'))
 
     var compiled = _.template(file.toString())
@@ -67,7 +61,12 @@ var PhantomJSBrowser = function (baseBrowserDecorator, config, args, logger) {
 
     fs.writeFileSync(captureFile, captureCode)
 
-    flags.push(captureFile)
+    // PhantomJS takes its script file as the first cmd-line argument
+    var flags = [captureFile].concat(providedFlags);
+    if (args.debug) {
+      flags.push('--remote-debugger-port=9000')
+      flags.push('--remote-debugger-autorun=yes')
+    }
 
     // and start phantomjs
     this._execCommand(this._getCommand(), flags)

--- a/index.js
+++ b/index.js
@@ -50,8 +50,8 @@ var PhantomJSBrowser = function (baseBrowserDecorator, config, args, logger) {
 
     var flags = _.clone(providedFlags);
     if (args.debug) {
-      flags = flags.concat('--remote-debugger-port=9000')
-      flags = flags.concat('--remote-debugger-autorun=yes')
+      flags.push('--remote-debugger-port=9000')
+      flags.push('--remote-debugger-autorun=yes')
     }
 
     var file = fs.readFileSync(path.join(__dirname, 'capture.template.js'))
@@ -67,7 +67,7 @@ var PhantomJSBrowser = function (baseBrowserDecorator, config, args, logger) {
 
     fs.writeFileSync(captureFile, captureCode)
 
-    flags = flags.concat(captureFile)
+    flags.push(captureFile)
 
     // and start phantomjs
     this._execCommand(this._getCommand(), flags)


### PR DESCRIPTION
This actually fixes two problems:

1. on repeated PhantomJS runs, flags were getting passed as cmd-line arguments multiple times because each run only appended new arguments to the end of the flags array used for the previous run
2. issue #45: script file should be passed as the first argument

There is also a tiny refactoring commit in there to use `Array.prototype.push() ` instead of `Array.prototype.concat()` to avoid unnecessary array copies.

Once this is merged, you can close issue #45 & reject pull requests #50 & #51 (have unresolved conflicts and implement parts of work done in this pull request).