### PR TITLE
fix: use phantomjs-prebuilt instead of deprecated phantomjs

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,7 +14,7 @@ var phantomJSExePath = function () {
   // Using the cmd as the process to execute causes problems cleaning up the processes
   // so we walk from the cmd to the phantomjs.exe and use that instead.
 
-  var phantomSource = require('phantomjs').path
+  var phantomSource = require('phantomjs-prebuilt').path
 
   if (path.extname(phantomSource).toLowerCase() === '.cmd') {
     return path.join(path.dirname(phantomSource), '//node_modules//phantomjs//lib//phantom//phantomjs.exe')
@@ -98,8 +98,8 @@ PhantomJSBrowser.prototype = {
   name: 'PhantomJS',
 
   DEFAULT_CMD: {
-    linux: require('phantomjs').path,
-    darwin: require('phantomjs').path,
+    linux: require('phantomjs-prebuilt').path,
+    darwin: require('phantomjs-prebuilt').path,
     win32: phantomJSExePath()
   },
   ENV_CMD: 'PHANTOMJS_BIN'

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   },
   "peerDependencies": {
     "karma": ">=0.9",
-    "phantomjs": ">=1.9"
+    "phantomjs-prebuilt": ">=1.9"
   },
   "license": "MIT",
   "devDependencies": {
@@ -40,7 +40,7 @@
     "karma": "^0.13.6",
     "karma-jasmine": "^0.3.5",
     "load-grunt-tasks": "^3.2.0",
-    "phantomjs": "^1.9.19"
+    "phantomjs-prebuilt": "^2.1.3"
   },
   "contributors": [
     "dignifiedquire <dignifiedquire@gmail.com>",


### PR DESCRIPTION
The npm package [`phantomjs`](https://www.npmjs.com/package/phantomjs) is deprecated and renamed to [`phantomjs-prebuilt`](https://www.npmjs.com/package/phantomjs-prebuilt).

Issue: https://github.com/Medium/phantomjs/issues/447
Commit: https://github.com/Medium/phantomjs/commit/1c3cb052b3e4c318aaf6e0102d9a900af41f5f7b

> **Pre-2.0, this package was published to NPM as [phantomjs](https://www.npmjs.com/package/phantomjs).
> We changed the name to [phantomjs-prebuilt](https://www.npmjs.com/package/phantomjs-prebuilt) at the request of PhantomJS team.**
>
> **Please update your package references from `phantomjs` to `phantomjs-prebuilt`**
