### PR TITLE
Add phantomjs-prebuilt to dependency list

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,11 +17,11 @@
   ],
   "author": "Vojta Jina <vojta.jina@gmail.com>",
   "dependencies": {
-    "lodash": "^4.0.1"
+    "lodash": "^4.0.1",
+    "phantomjs-prebuilt": "^2.1.7"
   },
   "peerDependencies": {
-    "karma": ">=0.9",
-    "phantomjs-prebuilt": ">=1.9"
+    "karma": ">=0.9"
   },
   "license": "MIT",
   "devDependencies": {
@@ -39,8 +39,7 @@
     "jasmine-core": "^2.3.4",
     "karma": "1.x || ^0.13.6",
     "karma-jasmine": "1.x || ^0.3.5",
-    "load-grunt-tasks": "^3.2.0",
-    "phantomjs-prebuilt": "^2.1.3"
+    "load-grunt-tasks": "^3.2.0"
   },
   "contributors": [
     "Vojta Jina <vojta.jina@gmail.com>",


### PR DESCRIPTION
In order to have it automatically installed as a peer dependency in
npm@3 as well as in npm@2.

Closes https://github.com/karma-runner/karma-phantomjs-launcher/issues/104