### PR TITLE
fix: incorrect phantomjs path calculation

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,7 +17,8 @@ var phantomJSExePath = function () {
   var phantomSource = require('phantomjs-prebuilt').path
 
   if (path.extname(phantomSource).toLowerCase() === '.cmd') {
-    return path.join(path.dirname(phantomSource), '//node_modules//phantomjs//lib//phantom//phantomjs.exe')
+    var phantomPackage = require('phantomjs-prebuilt/package.json')
+    return path.join(path.dirname(phantomSource), '//node_modules//phantomjs//lib//phantom//', phantomPackage.bin.phantomjs)
   }
 
   return phantomSource


### PR DESCRIPTION
Starting from phantomjs-prebuild@2.1.2, binary path for windows changed from phantomjs//lib//phantom//phantomjs.exe to phantomjs//lib//phantom//bin//phantomjs.exe.
The fix is to read binary path from package.json.

For me, this is the cause of the issue #84 when running on Windows.